### PR TITLE
RUBY-3492: Add SBOM lite file and tooling to update it

### DIFF
--- a/README.maint.md
+++ b/README.maint.md
@@ -12,8 +12,9 @@ derived from `libmongocrypt` version as described below.
 3. Download the source code of the corresponding version of `libmongocrypt` from
 https://github.com/mongodb/libmongocrypt/releases/, and unpack it to
 `ext/libmongocrypt/libmongocrypt`.
-4. Commit the changes including the new shared library.
-5. Run `./release.sh` to create a gem and push it to RubyGems.
+4. Update the SBOM lite file by running `etc/update-sbom.sh`
+5. Commit the changes including the new shared library.
+6Run `./release.sh` to create a gem and push it to RubyGems.
 
 ## Helper Version Scheme
 

--- a/etc/update-sbom.sh
+++ b/etc/update-sbom.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+ROOT_DIR=$(realpath "${SCRIPT_DIR}/../")
+VERSION_FILE="${ROOT_DIR}/lib/libmongocrypt_helper/version.rb"
+PURLS_FILE="${ROOT_DIR}/purls.txt"
+
+# Extract libmongocrypt version from version file. The sequence "'\''" in sed matches a single quote
+LIBMONGOCRYPT_VERSION=$(grep -e "LIBMONGOCRYPT_VERSION = " ${VERSION_FILE} | sed -n -e 's/^.*LIBMONGOCRYPT_VERSION = '\''\(.*\)'\''$/\1/p')
+
+# Generate purls file from stored versions
+echo "pkg:github/mongodb/libmongocrypt@${LIBMONGOCRYPT_VERSION}" > $PURLS_FILE
+
+# Use silkbomb to update the sbom.json file
+docker run --platform="linux/amd64" -it --rm -v ${ROOT_DIR}:/pwd \
+  artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 \
+  update --sbom-in /pwd/sbom.json --purls /pwd/purls.txt --sbom-out /pwd/sbom.json
+
+rm $PURLS_FILE

--- a/sbom.json
+++ b/sbom.json
@@ -1,0 +1,76 @@
+{
+  "components": [
+    {
+      "bom-ref": "pkg:github/mongodb/libmongocrypt@1.8.0",
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://github.com/mongodb/libmongocrypt/archive/refs/tags/1.8.0.tar.gz"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/mongodb/libmongocrypt/tree/1.8.0"
+        }
+      ],
+      "group": "mongodb",
+      "name": "libmongocrypt",
+      "purl": "pkg:github/mongodb/libmongocrypt@1.8.0",
+      "type": "library",
+      "version": "1.8.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:github/mongodb/libmongocrypt@1.8.0"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2024-06-12T07:24:32.253682+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "6.4.4"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:67ce9be7-c1c0-436f-a7d7-c636db7b882b",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}


### PR DESCRIPTION
This adds an SBOM lite file containing the dependency to libmongocrypt. The `etc/update-sbom.sh` script can be used to update this file: it reads the libmongocrypt version from `lib/libmongocrypt_helper/version.rb`, generates a temporary purl file and runs the silkbomb tool to update the SBOM.