### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
   build:
     name: "Build Gem"
     needs: [pr-check]
+    environment: release
     runs-on: 'ubuntu-latest'
 
     permissions:


### PR DESCRIPTION
The "build gem" step of the release workflow was not using the `release` environment, which prevented it from seeing any of the variables defined in that environment.